### PR TITLE
set method

### DIFF
--- a/lib/jspath.js
+++ b/lib/jspath.js
@@ -1291,4 +1291,20 @@ exports.apply = function(path, ctx, substs) {
     return cache[path](ctx, substs || {});
 };
 
+exports.set = function(path, value, ctx, substs) {
+    var prepath = path.substring(0, path.lastIndexOf('.')) || '.',
+        key = path.substring(path.lastIndexOf('.') + 1, path.length),
+        res;
+
+    if (!key) {
+        return;
+    }
+
+    res = JSPath.apply(prepath + '{.' + key + '}', ctx, substs);
+
+    for (var i = 0; i < res.length; ++i) {
+        res[i][key] = value;
+    }
+}
+
 });


### PR DESCRIPTION
Set the value of the field object at the specified location path.
### Examples

``` javascript
// set Bender for author to all books
JSPath.set('.books.author.name', 'Bender', doc);

// set "Kill all humans!" for title to all books
JSPath.set('.books.title', 'Kill all humans!', doc);

// find all books author names
JSPath.apply('.books.author.name', doc);
/*['Bender', 'Bender', 'Bender', 'Bender'] */

// find all books titles
JSPath.apply('.books.title', doc);
/*['Kill all humans!', 'Kill all humans!', 'Kill all humans!', 'Kill all humans!'] */

```
