### PR TITLE
Expose Parse Tree

### DIFF
--- a/lib/jspath.js
+++ b/lib/jspath.js
@@ -1267,7 +1267,11 @@ var translate = (function() {
 })();
 
 function compile(path) {
-    return Function('data,subst', translate(parse(path)));
+    return compileParsed(parse(path));
+}
+
+function compileParsed(parseTree) {
+    return Function('data,subst', translate(parseTree));
 }
 
 var cache = {},
@@ -1314,6 +1318,8 @@ decl.params = function(_params) {
     }
 };
 
+decl.parse = parse;
+decl.compileParsed = compileParsed;
 decl.compile = compile;
 
 decl.apply = decl;


### PR DESCRIPTION
Expose two new functions (parse and compileParsed) for each step of the
compile process.
So that a user of the library may, if needed, transform the parse tree
before translating and compiling it into a function.